### PR TITLE
Stop showing "Updated at" after redownloading identical media files

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.java
@@ -19,6 +19,7 @@ import org.odk.collect.android.openrosa.HttpPostResult;
 import org.odk.collect.android.openrosa.OpenRosaConstants;
 import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.shared.strings.Md5;
+import org.odk.collect.shared.strings.RandomString;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -43,6 +44,7 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
     private boolean fetchingFormsError;
     private boolean noHashInFormList;
     private boolean noHashPrefixInMediaFiles;
+    private boolean randomHash;
 
     @NonNull
     @Override
@@ -150,6 +152,10 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
         noHashPrefixInMediaFiles = true;
     }
 
+    public void returnRandomMediaFileHash() {
+        randomHash = true;
+    }
+
     public String getURL() {
         return "https://" + HOST;
     }
@@ -233,7 +239,13 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
 
             for (String mediaFile : xformItem.getMediaFiles()) {
                 AssetManager assetManager = InstrumentationRegistry.getInstrumentation().getContext().getAssets();
-                String mediaFileHash = Md5.getMd5Hash(assetManager.open("media/" + mediaFile));
+                String mediaFileHash;
+
+                if (randomHash) {
+                    mediaFileHash = RandomString.randomString(8);
+                } else {
+                    mediaFileHash = Md5.getMd5Hash(assetManager.open("media/" + mediaFile));
+                }
 
                 stringBuilder
                         .append("<mediaFile>")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -110,6 +110,7 @@ abstract class Page<T : Page<T>> {
         return this as T
     }
 
+    @JvmOverloads
     fun assertTextThatContainsExists(text: String, index: Int = 0): T {
         onView(
             withIndex(
@@ -121,6 +122,21 @@ abstract class Page<T : Page<T>> {
                 index
             )
         ).check(matches(not(doesNotExist())))
+        return this as T
+    }
+
+    @JvmOverloads
+    fun assertTextThatContainsDoesNoExist(text: String, index: Int = 0): T {
+        onView(
+            withIndex(
+                withText(
+                    containsString(
+                        text
+                    )
+                ),
+                index
+            )
+        ).check(doesNotExist())
         return this as T
     }
 


### PR DESCRIPTION
Central currently doesn't return hashes that match the actual file MD5 hash for entity lists. This means that they will get redownloaded on every update check (match exactly or previously downloaded only). As well as the wasted redownload, this will confusingly make the form show up as "Updated at" after every update check (which could be as frequent as every 15 mins). This PR changes that so that we only show "Updated at" on forms where a redownloaded media file has actually changed.

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

Not sure if there are many alternatives here. The key change was to move the check about a media file being updated to after downloading so that we can compare the "new" file with the old one to see if there's actually been a change.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Changes to form download are always risky as it's a surprisingly complex area of the code and there are many hidden subtleties. It'd be good to check/think about different form download/update scenarios against various different servers.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
